### PR TITLE
Use user.html_url instead of user.url

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
   <script id="issue" class="partial" type="text/html">
     <li class="{{state}}" data-repo="{{repo_name}}" >
       <div class="authorPlaceholder">
-        <a class="author" href="{{user.url}}" title="Opened by {{user.login}}"><img src="{{user.avatar_url}}" alt=""></a>
+        <a class="author" href="{{user.html_url}}" title="Opened by {{user.login}}"><img src="{{user.avatar_url}}" alt=""></a>
       </div>
       <div class="assigneePlaceholder">
       {{#assignee}}


### PR DESCRIPTION
When using user.url you'll get a link to the API resource of the user (e.g. https://api.github.com/users/rmehner), but as you're showing it in a browser you most likely want the URL to the proper HTML GitHub profile (e.g.: https://github.com/rmehner).
