### PR TITLE
properly show closed issues

### DIFF
--- a/script/main.js
+++ b/script/main.js
@@ -561,7 +561,7 @@ $(function () {
   // 1
   // …
   // GO!
-  getIssues({state: 'open'})
+  getIssues()
   .then(mapDataItems)
   .then(removeDuplicates)
   .then(sortIssuesByDate)


### PR DESCRIPTION
The current ubersicht doesn't show any closed issues, and the "show closed issues" checkbox is completely defunct.

This change fixes the issue by fetching and displaying all issues, not just the open ones.

Would this be something you'd consider merging?
