### PR TITLE
Add second border-color for pull requests

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
   </script>
 
   <script id="issue" class="partial" type="text/html">
-    <li class="{{state}}" data-repo="{{repo_name}}" data-username="{{user.login}}" data-assignee="{{assignee.login}}" data-updatedat="{{updated_at}}" data-createdat="{{created_at}}" data-closedat="{{closed_at}}">
+    <li class="{{state}} {{#is_pull_request}}pull-request{{/is_pull_request}}" data-repo="{{repo_name}}" data-username="{{user.login}}" data-assignee="{{assignee.login}}" data-updatedat="{{updated_at}}" data-createdat="{{created_at}}" data-closedat="{{closed_at}}">
       <div class="authorPlaceholder">
         <a class="author" href="{{user.html_url}}" title="Opened by {{user.login}}"><img src="{{user.avatar_url}}" alt=""></a>
       </div>

--- a/script/main.js
+++ b/script/main.js
@@ -262,6 +262,7 @@ $(function () {
         if(issue.milestone){
           issue.milestone.html_url = issue.milestone.url.replace('api.', '').replace('repos/', '').replace('milestones/', 'issues?milestone=');
         }
+        issue.is_pull_request = issue.pull_request && issue.pull_request.html_url;
       } else {
         // If it's a duplicate, remove it
         issue = undefined;

--- a/style/style.css
+++ b/style/style.css
@@ -318,26 +318,31 @@ h6 a:hover {
   text-transform: uppercase;
 }
 
-.issues > .open{
-  border-left: 10px solid #EB6420;
-}
-
-.issues > .closed{
-  border-left: 10px solid #009800;
-}
-
-.issues > .pull-request{
-  border-left-width: 5px;
-}
-
-.issues > .pull-request:before {
-  border-left: 5px solid #2C2A86;
+.issues > li:before,
+.issues > li:after {
   display: block;
   position: absolute;
   height: 100%;
   content: '';
   left: 0;
   top: 0;
+}
+
+.issues > li:after {
+  left: 5px;
+  z-index: 10;
+}
+
+.issues > .open:before {
+  border-left: 10px solid #EB6420;
+}
+
+.issues > .closed:before {
+  border-left: 10px solid #009800;
+}
+
+.issues > .pull-request:after {
+  border-left: 5px solid #2C2A86;
 }
 
 .title {

--- a/style/style.css
+++ b/style/style.css
@@ -326,6 +326,20 @@ h6 a:hover {
   border-left: 10px solid #009800;
 }
 
+.issues > .pull-request{
+  border-left-width: 5px;
+}
+
+.issues > .pull-request:before {
+  border-left: 5px solid #2C2A86;
+  display: block;
+  position: absolute;
+  height: 100%;
+  content: '';
+  left: 0;
+  top: 0;
+}
+
 .title {
   font-size: 1.25em;
   line-height: 1.25em;


### PR DESCRIPTION
An attempt at #23.

It creates a second border (blue) for pull-requests so that you can still see the open/closed status.

![screen shot 2014-08-11 at 12 38 17 pm](https://cloud.githubusercontent.com/assets/542108/3881591/269cd7ba-218f-11e4-932b-e601b1969598.png)

Closes #23.
